### PR TITLE
Removed OptionsResolverInterface usage

### DIFF
--- a/Form/SpecTypeExtension.php
+++ b/Form/SpecTypeExtension.php
@@ -5,7 +5,6 @@ namespace Symfony\Bridge\RulerZ\Form;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 
 class SpecTypeExtension extends AbstractTypeExtension
@@ -18,7 +17,7 @@ class SpecTypeExtension extends AbstractTypeExtension
         $this->setDefaultOptions($resolver);
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function setDefaultOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'spec_transformer' => 'string', // string, array, boolean


### PR DESCRIPTION
Because [OptionsResolverInterface is deprecated](http://api.symfony.com/3.0/Symfony/Component/OptionsResolver/OptionsResolverInterface.html), it's now better to use `OptionsResolver`.